### PR TITLE
Fix broken gitbook by last push

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -22,7 +22,7 @@
    * [“The Blockchain is more than just Bitcoin”](bitcoin_transfer/the_blockchain_is_more_than_just_bitcoin.md)
    * [Spend your coin](bitcoin_transfer/spend_your_coin.md)
    * [Proof of ownership as an authentication method](bitcoin_transfer/proof_of_ownership_as_an_authentication_method.md)
-* [Key generation and encryption](key_generation/README.md)
+* [Key generation and encryption](key_generation/key_generation.md)
    * [Is it random enough?](key_generation/key_generation.md#is-it-random-enough)
    * [Key Derivation Function](key_generation/key_generation.md#key-derivation-function)
    * [Like the good ol’ days](key_generation/key_generation.md#like-the-good-ol-days)

--- a/key_generation/README.md
+++ b/key_generation/README.md
@@ -1,1 +1,0 @@
-# Key generation and encryption {#key-generation-encryption}

--- a/key_generation/key_generation.md
+++ b/key_generation/key_generation.md
@@ -1,3 +1,5 @@
+# Key generation and encryption {#key-generation-encryption}  
+
 ## Is it random enough? {#is-it-random-enough}
 
 When you call **new Key()**, under the hood, you are using a PRNG (Pseudo-Random-Number-Generator) to generate your private key. On windows, it uses the **RNGCryptoServiceProvider**, a .NET wrapper around the Windows Crypto API.


### PR DESCRIPTION
When the Key encryption and generation chapter was restructured it broke working with gitbook.  
At that commit everything has been merged together in one file, called key_generation/key_generation.md  
In gitbook editor when you try to click on the chapters it does not jump to the file.  
There was an empty key_generation/README.md, that only cointained the title.  
I deleted it and pointed the key generation and encryption chapter to the new file: key_generation/key_generation.md   
In the new file, I put the title of the chapter.  

This way at least when you click on the chapter in gitbook editor, you reach te file, but when you click on the lessons they are still not there.  

Either we merge my pull here and accept this compromise, or undo the restructuring commit and make the restructuring properly according to gitbook conventions (new file for every lesson). Or just undo the restructuring and go with the old version.  

In the future we should never do any restructuring, since it brakes the link paths, those might very well be referenced from other sites.