### PR TITLE
Capitalize B in IsCoinBase.

### DIFF
--- a/bitcoin_transfer/transaction.md
+++ b/bitcoin_transfer/transaction.md
@@ -149,7 +149,7 @@ With the previous outpoint's transaction ID we can review the information associ
 ```cs
 OutPoint firstPreviousOutPoint = transaction.Inputs.First().PrevOut;
 var firstPreviousTransaction = client.GetTransaction(firstPreviousOutPoint.Hash).Result.Transaction;
-Console.WriteLine(firstPreviousTransaction.IsCoinbase); // False
+Console.WriteLine(firstPreviousTransaction.IsCoinBase); // False
 ```  
 
 We could continue to trace the transaction IDs back in this manner until we reach a **coinbase transaction**, the transaction including the newly mined coin by a miner.  


### PR DESCRIPTION
Lowercase throws error, fixing this to uppercase B in IsCoinBase:

`Console.WriteLine(firstPreviousTransaction.IsCoinBase); // False`

`public bool IsCoinBase { get; }`