### PR TITLE
Updated example in transactions.md

### DIFF
--- a/bitcoin_transfer/transaction.md
+++ b/bitcoin_transfer/transaction.md
@@ -65,10 +65,10 @@ The relevant parts for now are the **inputs** and **outputs**. You can see that 
 List<ICoin> receivedCoins = transactionResponse.ReceivedCoins;
 foreach (var coin in receivedCoins)
 {
-    Money amount = coin.Amount;
+    Money amount = (Money) coin.Amount;
 
     Console.WriteLine(amount.ToDecimal(MoneyUnit.BTC));
-    var paymentScript = coin.ScriptPubKey;
+    var paymentScript = coin.GetScriptCode();
     Console.WriteLine(paymentScript);  // It's the ScriptPubKey
     var address = paymentScript.GetDestinationAddress(Network.Main);
     Console.WriteLine(address);

--- a/bitcoin_transfer/transaction.md
+++ b/bitcoin_transfer/transaction.md
@@ -68,7 +68,7 @@ foreach (var coin in receivedCoins)
     Money amount = (Money) coin.Amount;
 
     Console.WriteLine(amount.ToDecimal(MoneyUnit.BTC));
-    var paymentScript = coin.GetScriptCode();
+    var paymentScript = coin.TxOut.ScriptPubKey;
     Console.WriteLine(paymentScript);  // It's the ScriptPubKey
     var address = paymentScript.GetDestinationAddress(Network.Main);
     Console.WriteLine(address);


### PR DESCRIPTION
When going through the examples in transactions.md, the following example presented me with errors:
```cs
List<ICoin> receivedCoins = transactionResponse.ReceivedCoins;
foreach (var coin in receivedCoins)
{
    Money amount = coin.Amount;

    Console.WriteLine(amount.ToDecimal(MoneyUnit.BTC));
    var paymentScript = coin.ScriptPubKey;
    Console.WriteLine(paymentScript);  // It's the ScriptPubKey
    var address = paymentScript.GetDestinationAddress(Network.Main);
    Console.WriteLine(address);
    Console.WriteLine();
}
```

The first error pertained to the ICoin interface not having member definition for Money. Specifically, the error was,

> Cannot implicitly convert type 'NBitcoin.IMoney' to 'NBitcoin.Money'. An explicit conversion exists (are you missing a cast?)

I found casting the variable 'amount' to the implementation of the Money class solved this issue.

The next error pertained to the ScriptPubKey property that was accessed from the coin variable inside the foreach loop. The variable 'coin' is an ICoin, which according to it's [definition](https://github.com/MetacoSA/NBitcoin/blob/0814df9ee7b31e5afd905e5793961ad12aaba66f/NBitcoin/Coin.cs#L22) does not have a property ScriptPubKey, but rather a method call GetScriptCode(), which returns the ScriptPubKey.

I am using NBitcoin version 3.0.0.37. I am still very new to this library so I apologize if my corrections are not ideal or if I am forgetting something simple.