### PR TITLE
Remove case studies from table of contents

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -48,6 +48,4 @@
    * [Liquid Democracy](other_types_of_asset/liquid_democracy.md)
    * [Proof of Burn and Reputation](other_types_of_asset/proof_of_burn_and_reputation.md)
    * [Protecting your private keys](security/protecting_your_private_keys.md)
-* [Case studies](implementations/README.md)
-   * [HiddenBitcoin: Managing keys](implementations/hiddenbitcoinkey_storage_hd_wallet_md.md)
 


### PR DESCRIPTION
The case studies section did not sparked interest, as we initially thought, no new chapter had been added.  
I also discontinued [HiddenBitcoin](https://github.com/nopara73/HiddenBitcoin) and started implementing its successor, [HBitcoin](https://github.com/nopara73/HBitcoin). Over the years the Safe class, presented in the case studies has been hugely refactored and I would find difficult to keep up with such documentation. With HBitcoin, the chapter became pretty outdated.  
  
I would like to keep the links alive, in order to not break existing references, we should only remove it from the table of contents of the book.