### PR TITLE
Text and grammar changes to make it a bit clearer.

### DIFF
--- a/other_types_of_ownership/multi_sig.md
+++ b/other_types_of_ownership/multi_sig.md
@@ -1,9 +1,10 @@
 ## Multi Sig {#multi-sig}
 
-It is possible to have shared ownership over coins.  
-For that you will create a ```ScriptPubKey``` that represents a **m-of-n multi sig**, this means in order to spend the coins, **m** private keys will need to sign on the **n** different public key provided.
+It is possible to have shared ownership and control over coins. 
 
-Let’s create a multi sig with Bob, Alice, and Satoshi, where two of them are needed to spend a coin.  
+In order to demonstarte this we will create a ```ScriptPubKey``` that represents an **m-of-n multi sig**, this means that in order to spend the coins, **m** number of private keys will need to sign out of the **n** number of different public keys provided.
+
+Let’s create a multi sig with Bob, Alice and Satoshi, where two of them need to sign a transaction in order to spend a coin.  
 
 ```cs
 Key bob = new Key();
@@ -21,11 +22,11 @@ Console.WriteLine(scriptPubKey);
 2 0282213c7172e9dff8a852b436a957c1f55aa1a947f2571585870bfb12c0c15d61 036e9f73ca6929dec6926d8e319506cc4370914cd13d300e83fd9c3dfca3970efb 0324b9185ec3db2f209b620657ce0e9a792472d89911e0ac3fc1e5b5fc2ca7683d 3 OP_CHECKMULTISIG
 ```  
 
-As you can see, the ```scriptPubkey``` have the following form: ```<sigsRequired> <pubkeys…> <pubKeysCount> OP_CHECKMULTISIG```  
+As you can see, the ```scriptPubkey``` has the following form: ```<sigsRequired> <pubkeys…> <pubKeysCount> OP_CHECKMULTISIG```  
 
 The process for signing it is a little more complicated than just calling ```Transaction.Sign```, which does not work for multi sig.
 
-Even if we will talk more deeply about the subject, let’s use the ```TransactionBuilder``` for signing the transaction.
+Later we will talk more deeply about the subject but for now let’s use the ```TransactionBuilder``` for signing the transaction.
 
 Imagine the multi-sig ```scriptPubKey``` received a coin in a transaction called ```received```:
 
@@ -35,7 +36,7 @@ received.Outputs.Add(new TxOut(Money.Coins(1.0m), scriptPubKey));
 ```  
 
 Bob and Alice agree to pay Nico 1.0 BTC for his services.
-So they get the ```Coin``` they received from the transaction:  
+First they get the ```Coin``` they received from the transaction:  
 
 ```cs
 Coin coin = received.Outputs.AsCoins().First();
@@ -43,7 +44,7 @@ Coin coin = received.Outputs.AsCoins().First();
 
 ![](../assets/coin.png)  
 
-Then, with the ```TransactionBuilder```, create an **unsigned transaction**.  
+Then, with the ```TransactionBuilder```, they create an **unsigned transaction**.  
 
 ```cs
 BitcoinAddress nico = new Key().PubKey.GetAddress(Network.Main);
@@ -79,7 +80,7 @@ Transaction bobSigned =
 
 ![](../assets/bobSigned.png)  
 
-Now, Bob and Alice can combine their signature into one transaction.  
+Now, Bob and Alice can combine their signature into one transaction. This transaction will then be valid in terms of it's signatures as Bob and Alice have provided two of the signatures from the three that were initially provided. The requirements of the 'two-of-three' multi sig have therefore been met.
 
 ```cs
 Transaction fullySigned =
@@ -115,12 +116,12 @@ Console.WriteLine(fullySigned);
 }
 
 ```  
-The transaction is now ready to be sent on the network.
+The transaction is now ready to be sent to the network.
 
-Even if the Bitcoin network supports multi sig as explained here, one question worth asking is: How can you ask to a user who has no clue about bitcoin to pay on satoshi/alice/bob multi sig, since such ```scriptPubKey``` can’t be represented by easy to use Bitcoin Address like we have seen before?
+Even if the Bitcoin network supports multi sig as explained here, one question worth asking is: How can you ask a user who has no clue about bitcoin to pay using the satoshi/alice/bob multi sig as we have above, since such a ```scriptPubKey``` can’t be represented by a simple Bitcoin Address like the ones we have seen before?
 
-Don’t you think it would be cool if we could to represent such ```scriptPubKey``` as easily and compactly as a Bitcoin Address?
+Don’t you think it would be cool if we could represent such a ```scriptPubKey``` as easily and concisely as a regular Bitcoin Address?
 
-Well, this is possible and it is called a **Bitcoin Script Address** also called Pay to Script Hash. (P2SH)
+Well, this is possible using something called a **Bitcoin Script Address** (also called Pay to Script Hash or P2SH for short).
 
-Nowadays, **native Pay To Multi Sig** as you have seen here, and **native P2PK**, are never used directly as such, they are wrapped into **Pay To Script Hash** payment.
+Nowadays, **native Pay To Multi Sig** (as you have seen above) and **native P2PK** are never used directly. Instead they are wrapped into something called a **Pay To Script Hash** payment. We will look at this type of payment in the next section.

--- a/other_types_of_ownership/multi_sig.md
+++ b/other_types_of_ownership/multi_sig.md
@@ -2,9 +2,9 @@
 
 It is possible to have shared ownership and control over coins. 
 
-In order to demonstrate this we will create a ```ScriptPubKey``` that represents an **m-of-n multi sig**, this means that in order to spend the coins, **m** number of private keys will need to sign out of the **n** number of different public keys provided.
+In order to demonstrate this we will create a ```ScriptPubKey``` that represents an **m-of-n multi sig**. This means that in order to spend the coins, **m** number of private keys will need to sign the spending transaction out of the **n** number of different public keys provided.
 
-Let’s create a multi sig with Bob, Alice and Satoshi, where two of them need to sign a transaction in order to spend a coin.  
+Let’s create a multi sig with Bob, Alice and Satoshi, where two of the three of them need to sign a transaction in order to spend a coin.  
 
 ```cs
 Key bob = new Key();
@@ -80,7 +80,7 @@ Transaction bobSigned =
 
 ![](../assets/bobSigned.png)  
 
-Now, Bob and Alice can combine their signature into one transaction. This transaction will then be valid in terms of it's signatures as Bob and Alice have provided two of the signatures from the three that were initially provided. The requirements of the 'two-of-three' multi sig have therefore been met.
+Now, Bob and Alice can combine their signature into one transaction. This transaction will then be valid in terms of it's signature as Bob and Alice have provided two of the signatures from the three owner signatures that were initially provided. The requirements of the 'two-of-three' multi sig have therefore been met.
 
 ```cs
 Transaction fullySigned =
@@ -118,7 +118,7 @@ Console.WriteLine(fullySigned);
 ```  
 The transaction is now ready to be sent to the network.
 
-Even if the Bitcoin network supports multi sig as explained here, one question worth asking is: How can you ask a user who has no clue about bitcoin to pay using the satoshi/alice/bob multi sig as we have above, since such a ```scriptPubKey``` can’t be represented by a simple Bitcoin Address like the ones we have seen before?
+Even if the Bitcoin network supports multi sig as explained here, one question worth asking is: How can you expect a user who has no clue about bitcoin to pay using the Alice/Bob/Satoshi multi-sig as we have done above?
 
 Don’t you think it would be cool if we could represent such a ```scriptPubKey``` as easily and concisely as a regular Bitcoin Address?
 

--- a/other_types_of_ownership/multi_sig.md
+++ b/other_types_of_ownership/multi_sig.md
@@ -2,7 +2,7 @@
 
 It is possible to have shared ownership and control over coins. 
 
-In order to demonstarte this we will create a ```ScriptPubKey``` that represents an **m-of-n multi sig**, this means that in order to spend the coins, **m** number of private keys will need to sign out of the **n** number of different public keys provided.
+In order to demonstrate this we will create a ```ScriptPubKey``` that represents an **m-of-n multi sig**, this means that in order to spend the coins, **m** number of private keys will need to sign out of the **n** number of different public keys provided.
 
 Let’s create a multi sig with Bob, Alice and Satoshi, where two of them need to sign a transaction in order to spend a coin.  
 

--- a/other_types_of_ownership/p2sh_pay_to_script_hash.md
+++ b/other_types_of_ownership/p2sh_pay_to_script_hash.md
@@ -1,8 +1,8 @@
 ## P2SH (Pay To Script Hash) {#p2sh-pay-to-script-hash}
 
-As seen previously, using multi-sig is easily done in code. However, before P2SH there was no way to ask someone to pay to a multi-sig ```scriptPubKey``` in as way that was as simple as just providing them with a regular ```BitcoinAddress```.  
+As seen in the previous section, using multi-sig is easily done in code. However, before P2SH there was no way to ask someone to pay to a multi-sig ```scriptPubKey``` in a way that was as simple as just providing them with a regular ```BitcoinAddress```.  
 
-**Pay To Script Hash** (or **P2SH** as it is often known), is an easy way to represent any ```scriptPubKey``` as a simple ```BitcoinScriptAddress```, no matter how complicated it is in terms of it's underlying m-of-n signature set up.
+**Pay To Script Hash** (or **P2SH** as it is often known), is an easy way to represent a ```scriptPubKey``` as a simple ```BitcoinScriptAddress```, no matter how complicated it is in terms of it's underlying m-of-n signature set up.
 
 In the previous part we generated this multi-sig:
 
@@ -97,4 +97,4 @@ ScriptCoin coin = received.Outputs.AsCoins().First()
 
 ![](../assets/ScriptCoin.png)  
 
-The rest of the code concerning transaction generation and signing is exactly the same as in the previous part about native multi sig.
+The rest of the code concerning transaction generation and signing is exactly the same as in the previous section about native multi sig.

--- a/other_types_of_ownership/p2sh_pay_to_script_hash.md
+++ b/other_types_of_ownership/p2sh_pay_to_script_hash.md
@@ -1,10 +1,10 @@
 ## P2SH (Pay To Script Hash) {#p2sh-pay-to-script-hash}
 
-As seen previously, Multi-Sig works easily in code, however, before p2sh, there was no way to ask a customer to pay to a multi-sig ```scriptPubKey``` as easily as we could hand him a ```BitcoinAddress```.  
+As seen previously, using multi-sig is easily done in code. However, before P2SH there was no way to ask someone to pay to a multi-sig ```scriptPubKey``` in as way that was as simple as just providing them with a regular ```BitcoinAddress```.  
 
-**P2SH**, or **Pay To Script Hash**, is an easy way to represent any ```scriptPubKey``` as a simple ```BitcoinScriptAddress```, no matter how complicated it is.
+**Pay To Script Hash** (or **P2SH** as it is often known), is an easy way to represent any ```scriptPubKey``` as a simple ```BitcoinScriptAddress```, no matter how complicated it is in terms of it's underlying m-of-n signature set up.
 
-In the previous part we generated this multisig:
+In the previous part we generated this multi-sig:
 
 ```cs
 Key bob = new Key();
@@ -24,7 +24,7 @@ Console.WriteLine(scriptPubKey);
 
 Complicated isn’t it?
 
-Instead, let’s see how such ```scriptPubKey``` would look like as a **P2SH** payment.
+Instead, let’s see how such a ```scriptPubKey``` would look in a **P2SH** payment.
 
 ```cs
 Key bob = new Key();
@@ -42,9 +42,9 @@ Console.WriteLine(paymentScript);
 OP_HASH160 57b4162e00341af0ffc5d5fab468d738b3234190 OP_EQUAL
 ```  
 
-Do you see the difference? This p2sh ```scriptPubKey``` represents the hash of my multi-sig script: ```redeemScript.Hash.ScriptPubKey```
+Do you see the difference? This P2SH ```scriptPubKey``` represents the hash of the multi-sig script: ```redeemScript.Hash.ScriptPubKey```
 
-Since it is a hash, you can easily convert it as a base58 string ```BitcoinScriptAddress```.
+Since it is a hash, you can easily convert it to a base58 string ```BitcoinScriptAddress```.
 
 ```cs
 Key bob = new Key();
@@ -59,17 +59,17 @@ Script redeemScript =
 Console.WriteLine(redeemScript.Hash.GetAddress(Network.Main)); // 3E6RvwLNfkH6PyX3bqoVGKzrx2AqSJFhjo
 ```  
 
-Such address is understood by any client wallet. Even if such wallet does not understand what “multi sig” is.
+Such an address will still be understood by any existing client wallet, even if the wallet does not understand what “multi-sig” is.
 
-In P2SH payment, we refer as the **Redeem Script**, the ```scriptPubKey``` that got hashed.  
+In P2SH payments, we refer to the hash of the **Redeem Script** as the ```scriptPubKey```.  
 
 ![](../assets/RedeemScript.png)  
 
-Since the payer only knows about the **Hash of the RedeemScript**, he does not know the **Redeem Script**, and so, in our case, don’t even have to know that he is sending money to a multi sig of Bob/Satoshi/Alice.  
+Since anyone sending a payment to such an address only sees the **Hash of the RedeemScript**, and do not know the **Redeem Script** itself, they don’t even have to know that they are sending money to a multi sig of Alice/Bob/Satoshi.  
 
-Signing such transaction is similar to what we have done before. The only difference is that you have to provide the **Redeem Script** when you build the Coin for the **TransactionBuilder**
+Signing such a transaction is similar to what we have done before. The only difference is that you also have to provide the **Redeem Script** when you build the Coin for the **TransactionBuilder**.
 
-Imagine that the multi sig P2SH receive a coin in a transaction called ```received```.  
+Imagine that the multi-sig P2SH receives a coin in a transaction called ```received```.  
 
 ```cs
 Script redeemScript =
@@ -86,7 +86,7 @@ received.Outputs.Add(new TxOut(Money.Coins(1.0m), redeemScript.Hash));
 
 > Warning: The payment is sent to ```redeemScript.Hash``` and not to ```redeemScript```!  
 
-Then, once alice/bob/satoshi want to spend what they received, instead of creating a ```Coin``` they create a ```ScriptCoin```.  
+When any two owners out of the three that control the multi-sig address (Alice/Bob/Satoshi) then want to spend what they have received, instead of creating a ```Coin``` they will need to create a ```ScriptCoin```.  
 
 ```cs
 //Give the redeemScript to the coin for Transaction construction
@@ -97,4 +97,4 @@ ScriptCoin coin = received.Outputs.AsCoins().First()
 
 ![](../assets/ScriptCoin.png)  
 
-The rest of the code concerning transaction generation and signing is exactly the same as in the previous part with native multi sig.
+The rest of the code concerning transaction generation and signing is exactly the same as in the previous part about native multi sig.


### PR DESCRIPTION
Minor grammar changes but please check the following that I have changed in p2sh_pay_to_script_hash.md

I have changed:

"In P2SH payment, we refer as the Redeem Script, the scriptPubKey that got hashed."

to...

"In P2SH payments, we refer to the hash of the Redeem Script as the scriptPubKey."