### PR TITLE
spend_your_coin.md: rather use blockr API link

### DIFF
--- a/bitcoin_transfer/spend_your_coin.md
+++ b/bitcoin_transfer/spend_your_coin.md
@@ -209,7 +209,7 @@ I have 3 **TxOut**, 2 with **value**, 1 without **value** (which contains the me
 Take a closer look at **TxIn**. We have **prev_out** and **scriptSig** there.  
 **Exercise:** try to figure out what **scriptSig** will be and how to get it in our code before you read further!  
 
-Let's check out the **hash** of **prev_out** in a blockexplorer: http://tbtc.blockr.io/tx/info/e44587cf08b4f03b0e8b4ae7562217796ec47b8c91666681d71329b764add2e3  
+Let's check out the **hash** of **prev_out** in a blockexplorer: http://tbtc.blockr.io/api/v1/tx/info/e44587cf08b4f03b0e8b4ae7562217796ec47b8c91666681d71329b764add2e3  
 In **prev_out** **n** is 1. Since we are indexing from 0, this means I want to spend the second output of the transaction.  
 In the blockexplorer we can see the corresponding address is ```mzK6Jy5mer3ABBxfHdcxXEChsn3mkv8qJv``` and I can get the scriptSig from the address like this:  
 


### PR DESCRIPTION
This link didn't show the raw transaction in JSON format, so it's not very helpful. Use rather the blockr API link.