### PR TITLE
Please anyone consults my question about Segwit

### DIFF
--- a/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash.md
+++ b/other_types_of_ownership/p2wpkh_pay_to_witness_public_key_hash.md
@@ -9,7 +9,7 @@ There are several reasons why it is beneficial to use this new scheme, a summary
 *   **Signing of input values:** The amount that is spent in an input is also signed, meaning that the signer can’t be tricked about the amount of fees that are actually being paid.
 *   **Capacity increase:** It will now be possible to have more than 1MB of transactions in each block (which are created every 10 minutes on average). Segwit increases this capacity by a factor of about 2.1, based upon the average transaction profile from November 2016.
 *   **Fraud proof:** Will be developed later, but SPV wallets will be able to validate more consensus rules rather than just simply following the longest chain.
-
+ 
 Before Sewgit the transaction signature was used in the calculation of the transaction id.  
 
 ![](../assets/segwit.png)


### PR DESCRIPTION
1. 
  At this sentence:
  Before Segwit the transaction signature was used in the calculation of the transaction id.
  
    
  What's "the transaction signature" meaning?
  
  Is it a ScriptSig in a input of a transaction?
  
  As to the above sentence, can I say like this:
  (According to an illustration, it looks like, since TxId is generated by inputs and outputs,)
  Before Sewgit the transaction signature(ScriptSig) was used in the calculation of the transaction id along with other values of input and entire of output.
  
  
  
  2. 
  At this sentence:
  Linear sig hash scaling: Signing a transaction used to require hashing the whole transaction for every input. This was a potential DDoS vector attack for large transactions.
  
  Considering this part:
  Signing a transaction used to require hashing the whole transaction for every input.
  
  Signing a transaction means generating transactionID?
  
  If generating transactionID requires hashing the "whole transaction", the "whole transaction" means block header(previous transactionID, metadata, and so on) + block body(inputs, outputs) or only body part?
  
  3.
  On an illustration, on the left one, Signature1 and Signature2 mean the ScriptSig? Is it possible to exsist multiple ScriptSigs in one input?
  
  4.
  On an illustration, on the right one, even though the Signature1 and Signature2 are located out of both inputs and outputs, Signature1 and Signature2 values are located in input, according to this sentence:
  Basically, Segregated Witness moves the proof of ownership from the scriptSig part of the transaction to a new part called the witness of the input.
  
  Can I say that the reason for the location of Signatures on an illustration is just to show after Segwit TxId is generated by inputs and outputs without Signature(previously ScriptSig value) which is after the Segwit, the value of witness in a input?