### PR TITLE
KeyId.GetAddress() accepts only Network type.

### DIFF
--- a/bitcoin_transfer/payment_script.md
+++ b/bitcoin_transfer/payment_script.md
@@ -14,8 +14,8 @@ We are able to generate the ScriptPubKey from the Bitcoin Address. This is a ste
 ```cs 
 var publicKeyHash = new KeyId("14836dbe7f38c5ac3d49e8d790af808a4ee9edcf");
 
-var testNetAddress = publicKeyHash.GetAddress(ScriptPubKeyType.Legacy, Network.TestNet);
-var mainNetAddress = publicKeyHash.GetAddress(ScriptPubKeyType.Legacy, Network.Main);
+var testNetAddress = publicKeyHash.GetAddress(Network.TestNet);
+var mainNetAddress = publicKeyHash.GetAddress(Network.Main);
 
 Console.WriteLine(mainNetAddress.ScriptPubKey); // OP_DUP OP_HASH160 14836dbe7f38c5ac3d49e8d790af808a4ee9edcf OP_EQUALVERIFY OP_CHECKSIG
 Console.WriteLine(testNetAddress.ScriptPubKey); // OP_DUP OP_HASH160 14836dbe7f38c5ac3d49e8d790af808a4ee9edcf OP_EQUALVERIFY OP_CHECKSIG


### PR DESCRIPTION
The signature of `KeyId.GetAddress()` method is as follows. It indicates this method accepts only Network type. `ScriptPubKeyType` argument is not acceptable, so they should be removed.

```
public class KeyId : TxDestination
{
    public override BitcoinAddress GetAddress(Network network);
}
```